### PR TITLE
Aspect ratio definition and parent option

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function ($elements, opts) {
         _ratios.x = _element.getAttribute('height') / _element.getAttribute('width')
         return _ratios
       } else if (_element.hasAttribute('data-aspect-ratio')) {
-        var _ratio = _element.getAttribute('data-aspect-ratio').split('x')
+        var _ratio = _element.getAttribute('data-aspect-ratio').split(':')
         _ratios.y = parseInt(_ratio[0]) / parseInt(_ratio[1])
         _ratios.x = parseInt(_ratio[1]) / parseInt(_ratio[0])
         return _ratios

--- a/index.js
+++ b/index.js
@@ -71,12 +71,15 @@ module.exports = function ($elements, opts) {
         _dimensions.h = window.innerHeight
         return _dimensions
       }
+      if(typeof _parent === 'object' && !helpers.isElement(_parent)){
+        _parent = _parent[0]
+      }
       if (helpers.isElement(_parent)) {
         _dimensions.w = _parent.clientWidth
         _dimensions.h = _parent.clientHeight
         return _dimensions
       }
-      if (_parent = closest(_element, _parent, false) || document.querySelector(_parent)) {
+      if (_parent = closest(_element, _parent) || document.querySelector(_parent)) {
         _dimensions.w = _parent.clientWidth
         _dimensions.h = _parent.clientHeight
         return _dimensions
@@ -113,7 +116,7 @@ module.exports = function ($elements, opts) {
 
     _parent = helpers.parentDimensions(_element, options.parent)
     if (!_parent) {
-      console.error('Parent option invalid')
+      console.error('Invalid parent option')
       return
     }
 

--- a/package.json
+++ b/package.json
@@ -13,13 +13,14 @@
   "author": "Jon-Kyle Mohr",
   "license": "ISC",
   "dependencies": {
+    "closest": "0.0.1",
     "extend": "~2.0.0"
   },
   "devDependencies": {
     "watchify": "^2.3.0"
   },
-  "repository" : {
-    "type": "git", 
+  "repository": {
+    "type": "git",
     "url": "https://github.com/jondashkyle/mediaSize"
   }
 }


### PR DESCRIPTION
### Aspect Ratio

Specify aspect ratio of the element to be resized using a `data-aspect-ratio` attribute, instead of only having the option of using `width` and `height` attributes. The `width` and `height` attributes take precedence, but then it checks for the  `data-aspect-ratio` attribute. Use colon formatted aspect ratio:

```
<video src="video.mp4" data-aspect-ratio="16:9">
```
### Parent Option

Specify parent to use as the to resize to. Acceptable values are:
- nothing, `window`, or `'window'` will default to `window` as parent
- element (jQuery object also ok) to use as parent. If array of elements is passed, will use the first
- valid selector, will first search the ancestors of the element to be resized for a match, failing there being an ancestor, will query the dom for a match

The following example will check each `video` for an ancestor with a `data-media-frame` attribute. If no ancestor, will query the dom to see if one exists somewhere and use that

```
var media = mediasize(document.querySelectorAll('video'), {
  parent : '[data-media-frame]'
})
```

Code for checking parent is a lil convoluted and could be cleaner...
